### PR TITLE
voronoi merger inherits mask merger, make destructor virtual

### DIFF
--- a/lib/src/core1/maskMerger.hpp
+++ b/lib/src/core1/maskMerger.hpp
@@ -33,7 +33,7 @@ class MaskMerger {
 
   static MaskMerger* factor(const MaskMergerType maskMergerType);
 
-  ~MaskMerger();
+  virtual ~MaskMerger();
 
   virtual Status setParameters(const std::vector<double>& params) = 0;
 

--- a/lib/src/core1/voronoiMaskMerger.hpp
+++ b/lib/src/core1/voronoiMaskMerger.hpp
@@ -14,7 +14,7 @@ namespace Core {
 class VoronoiMaskMerger : public MaskMerger {
  public:
   VoronoiMaskMerger() : feather(0) {}
-  ~VoronoiMaskMerger() {}
+  virtual ~VoronoiMaskMerger() override {}
 
   Status setup(const PanoDefinition&, GPU::Buffer<const uint32_t> inputsMask, const ImageMapping& fromIm,
                const ImageMerger* const to, GPU::Stream) override;


### PR DESCRIPTION
Fixes #30.

MaskMerger factory produces a VoronoiMaskMerger: https://github.com/stitchEm/stitchEm/blob/master/lib/src/core1/maskMerger.cpp#L41

But the MaskMerger (base class) is later deleted: https://github.com/stitchEm/stitchEm/blob/master/lib/src/core1/imageMerger.hpp#L93

Thus the destructor should be virtual.

The destructor was never virtual, code is 4 years old, wonder why this wasn't an issue before. Maybe this is UB and a recent clang version does some optimisation that blows up?
