### PR TITLE
remove openal from MacPorts deps

### DIFF
--- a/doc/BUILD.md
+++ b/doc/BUILD.md
@@ -13,7 +13,7 @@ Using ccache to speed up recompilation is recommended, but not required, on Linu
 sudo port install CMake bison doxygen yasm ninja ccache
 
 # Libraries
-sudo port install opencv glew gsed jpeg libpng openal \
+sudo port install opencv glew gsed jpeg libpng \ 
           tiff faac faad2 ceres-solver glfw ffmpeg glm OpenEXR
 ```
 


### PR DESCRIPTION
OpenAL support was removed and replaced by PortAudio. Updating the build doc for Mac.

Fixes #45.

