### PR TITLE
fix CUDA runtime errors caused by /GL compiler option

### DIFF
--- a/lib/libvideostitch_CUDA.cmake
+++ b/lib/libvideostitch_CUDA.cmake
@@ -136,8 +136,20 @@ cuda_include_directories(src ${CMAKE_EXTERNAL_DEPS}/include)
 cuda_include_directories(${VS_DISCOVERY_PUBLIC_HEADERS_DIR})
 cuda_include_directories(${VS_LIB_PUBLIC_HEADERS_DIR})
 
+if(MSVC)
+  string(FIND ${CMAKE_CXX_FLAGS_RELEASE} "/GL" CONTAINS_GL_FLAG)
+  # /GL option will cause CUDA runtime errors when building with Visual Studio 2017 and CUDA 10.2
+  STRING(REPLACE " /GL" "" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
+endif()
+
 # CMake object libs don't work with CUDA
 cuda_compile(BACKEND_OBJECTS_CUDA ${CUDA_SOURCES})
+
+if(MSVC)
+  if (CONTAINS_GL_FLAG GREATER 0)
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /GL")
+  endif()
+endif()
 
 add_library(${VS_LIB_OBJECTS_CUDA} OBJECT ${CORE_LIB_SOURCES} ${CORE_LIB_HEADERS} ${CUDA_BACKEND_SOURCES} ${CUDA_BACKEND_HEADERS})
 add_cppcheck(${VS_LIB_OBJECTS_CUDA} VS)


### PR DESCRIPTION
fixes issue of #49 
Adding /GL (Whole Program Optimization) compiler option to nvcc.exe will cause CUDA runtime errors when building with vs2017。This can also be reproduced by nvidia official CUDA samples. (Sample jacobiCudaGraphs tested)