### PR TITLE
Rtmp in av

### DIFF
--- a/IO/src/common/format/src/util.cpp
+++ b/IO/src/common/format/src/util.cpp
@@ -131,12 +131,12 @@ const std::string errorString(const int errorCode) {
 #ifndef __clang_analyzer__
 bool isStream(const std::string& filename) {
   std::regex rtsp("RTSP://", std::regex_constants::ECMAScript | std::regex_constants::icase);
-  // std::regex rtmp("RTMP://", std::regex_constants::ECMAScript | std::regex_constants::icase);
+   std::regex rtmp("RTMP://", std::regex_constants::ECMAScript | std::regex_constants::icase);
   if (std::regex_search(filename, rtsp)) {
     return true;
-  } /*else if (std::regex_search(filename, rtmp)) {
+  } else if (std::regex_search(filename, rtmp)) {
     return true;
-  }*/
+  }
   return false;
 }
 #endif  // __clang_analyzer__

--- a/apps/src/libvideostitch-gui/utils/inputformat.hpp
+++ b/apps/src/libvideostitch-gui/utils/inputformat.hpp
@@ -56,7 +56,7 @@ static inline QString getDisplayNameFromEnum(const InputFormatEnum& value) {
     case InputFormatEnum::AJA:
       return QCoreApplication::translate("InputFormat", "AJA (BETA)");
     case InputFormatEnum::NETWORK:
-      return QCoreApplication::translate("InputFormat", "RTSP inputs");
+      return QCoreApplication::translate("InputFormat", "RTSP/RTMP inputs");
     case InputFormatEnum::V4L2:
       return QCoreApplication::translate("InputFormat", "Video for Linux Two");
     case InputFormatEnum::INVALID:


### PR DESCRIPTION
## Summary
Allow to use RTMP inputs in the standard AV module (ie ffmpeg)
Because historical module was used with intel quicksync but people without HW/Feature should be able to use it.

## Review
Not much

## Test coverage
- [ ] code already covered by the following tests:
- [ ] a new unit test is provided with this change set
- [ ] a new command line test is provided with this change set
- [ ] a new squish test is provided with this change set
- [X] no test needed: manual
