### PR TITLE
OpenCV4 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Deps
-      run: brew install bison ceres-solver CMake doxygen faac faad2 ffmpeg glew glfw glm jpeg libpng libtiff ninja opencv@3 qt yasm
+      run: brew install bison ceres-solver CMake doxygen faac faad2 ffmpeg glew glfw glm jpeg libpng libtiff ninja opencv qt yasm
     - name: CMake
       run: mkdir build && cd build && PATH="/usr/local/opt/bison/bin:${PATH}" cmake -DCREATE_BOX_PACKAGE=OFF -DGPU_BACKEND_CUDA=OFF -DGPU_BACKEND_OPENCL=ON -DMACPORTS=OFF -DQt5_DIR=/usr/local/opt/qt/lib/cmake/Qt5 -G Ninja ..
     - name: Build

--- a/lib/src/autocrop/autoCrop.cpp
+++ b/lib/src/autocrop/autoCrop.cpp
@@ -82,7 +82,7 @@ Status AutoCrop::setupImage(const cv::Mat& inputImage) {
       inputCvImage, blurredImage,
       cv::Size((int)autoCropConfig.getGaussianBlurKernelSize(), (int)autoCropConfig.getGaussianBlurKernelSize()),
       autoCropConfig.getGaussianBlurSigma(), 0);
-  cv::cvtColor(blurredImage, inputLabImage, CV_BGR2Lab);
+  cv::cvtColor(blurredImage, inputLabImage, cv::COLOR_BGR2Lab);
 
   cv::Size downSize = cv::Size(inputLabImage.cols, inputLabImage.rows);
   while (downSize.width > 512 && downSize.height > 512) {

--- a/lib/src/autocrop/autoCropAlgorithm.cpp
+++ b/lib/src/autocrop/autoCropAlgorithm.cpp
@@ -57,7 +57,7 @@ Potential<Ptv::Value> AutoCropAlgorithm::apply(Core::PanoDefinition* pano, Progr
     std::memcpy(hostFrame.hostPtr(), frame.hostPtr(), frame.byteSize());
     cv::Mat cvImage;
     cv::Mat originalImage(cv::Size((int)width, (int)height), CV_8UC4, frame.hostPtr(), cv::Mat::AUTO_STEP);
-    cv::cvtColor(originalImage, cvImage, CV_RGBA2BGR);
+    cv::cvtColor(originalImage, cvImage, cv::COLOR_RGBA2BGR);
 
     cv::Point3i circle;
     FAIL_RETURN(autoCrop.findCropCircle(cvImage, circle));

--- a/lib/src/calibration/keypointExtractor.cpp
+++ b/lib/src/calibration/keypointExtractor.cpp
@@ -12,7 +12,7 @@ KeypointExtractor::KeypointExtractor(unsigned int nb_octaves, unsigned int nb_su
   this->nOctaves = nb_octaves;
   this->nSubLevels = nb_sublevels;
   this->threshold = threshold;
-  extractor = cv::AKAZE::create(5, 0, 3, (float)threshold, nOctaves, nSubLevels, 1);
+  extractor = cv::AKAZE::create(AKAZE::DESCRIPTOR_MLDB, 0, 3, (float)threshold, nOctaves, nSubLevels, KAZE::DIFF_PM_G2);
 }
 
 Status KeypointExtractor::extract(const cv::Mat& image, KPList& keypoints, DescriptorList& descriptors,

--- a/lib/src/epipolar/epipolarCurvesAlgorithm.cpp
+++ b/lib/src/epipolar/epipolarCurvesAlgorithm.cpp
@@ -274,7 +274,7 @@ static Status loadInputImages(std::map<frameid_t, std::vector<cv::Mat>>& inputIm
 
       cv::Mat bgrImage;
       cv::Mat rgbaImage(cv::Size(width, height), CV_8UC4, frame.hostPtr(), cv::Mat::AUTO_STEP);
-      cv::cvtColor(rgbaImage, bgrImage, CV_RGBA2BGR);
+      cv::cvtColor(rgbaImage, bgrImage, cv::COLOR_RGBA2BGR);
 
       inputImages[frameNumber].push_back(bgrImage);
 

--- a/lib/src/test/contourMatchingTest.cpp
+++ b/lib/src/test/contourMatchingTest.cpp
@@ -70,13 +70,13 @@ Status loadBoundaryCoords(const std::string& filename, int64_t& width, int64_t& 
   const int thresh = 100;
   cv::Mat src_gray;
   cv::Mat canny_output;
-  cv::cvtColor(image, src_gray, CV_RGBA2GRAY);
+  cv::cvtColor(image, src_gray, cv::COLOR_RGBA2GRAY);
   // Detect edges using canny
   cv::Canny(src_gray, canny_output, thresh, thresh * 2, 3);
   // Find contours
   std::vector<std::vector<cv::Point>> contours;
   std::vector<cv::Vec4i> hierarchy;
-  cv::findContours(canny_output, contours, hierarchy, CV_RETR_EXTERNAL, CV_CHAIN_APPROX_NONE, cv::Point(0, 0));
+  cv::findContours(canny_output, contours, hierarchy, cv::RETR_EXTERNAL, cv::CHAIN_APPROX_NONE, cv::Point(0, 0));
   points.clear();
   if (contours.size() > 0) {
     for (size_t i = 0; i < contours[0].size(); i++) {

--- a/lib/src/util/compressionUtils.cpp
+++ b/lib/src/util/compressionUtils.cpp
@@ -30,7 +30,7 @@ Status Compression::polylineEncodeBinaryMask(const int width, const int height, 
             "Corrupted input mask in polylines encoding (width * height != data.size())"};
   }
   FAIL_RETURN(
-      Util::GeometryProcessing::findImageContours<unsigned char>(size, data, 1, contours, CV_CHAIN_APPROX_TC89_KCOS));
+      Util::GeometryProcessing::findImageContours<unsigned char>(size, data, 1, contours, cv::CHAIN_APPROX_TC89_KCOS));
 
   std::vector<int> encodedSizes;
   for (size_t i = 0; i < contours.size(); i++) {

--- a/lib/src/util/geometryProcessingUtils.cpp
+++ b/lib/src/util/geometryProcessingUtils.cpp
@@ -395,7 +395,7 @@ Status GeometryProcessing::findImageContours(const cv::Size size, const std::vec
   cv::Mat src_gray(size, CV_8UC1, &image[0]);
   /// Find contours
   std::vector<cv::Vec4i> hierarchy;
-  cv::findContours(src_gray, contours, hierarchy, CV_RETR_EXTERNAL, method, cv::Point(0, 0));
+  cv::findContours(src_gray, contours, hierarchy, cv::RETR_EXTERNAL, method, cv::Point(0, 0));
   return Status::OK();
 }
 

--- a/lib/src/util/geometryProcessingUtils.hpp
+++ b/lib/src/util/geometryProcessingUtils.hpp
@@ -66,7 +66,7 @@ class VS_EXPORT GeometryProcessing {
    */
   template <typename T>
   static Status findImageContours(const cv::Size size, const std::vector<T>& data, const T bitMask,
-                                  std::vector<std::vector<cv::Point>>& points, const int method = CV_CHAIN_APPROX_NONE);
+                                  std::vector<std::vector<cv::Point>>& points, const int method = cv::CHAIN_APPROX_NONE);
 
   /**
    * @brief Draw polygon to an output buffer

--- a/lib/src/util/imageProcessingUtils.cpp
+++ b/lib/src/util/imageProcessingUtils.cpp
@@ -23,7 +23,7 @@ Status ImageProcessing::findCropCircle(const int& width, const int& height, void
   r = 0;
   cv::Mat originalImage(cv::Size(width, height), CV_8UC4, data);
   cv::Mat inputImage;
-  cv::cvtColor(originalImage, inputImage, CV_RGBA2BGR);
+  cv::cvtColor(originalImage, inputImage, cv::COLOR_RGBA2BGR);
   std::unique_ptr<VideoStitch::Ptv::Value> fake(VideoStitch::Ptv::Value::stringObject("fake"));
   VideoStitch::AutoCrop::AutoCropConfig config(algoConfig ? algoConfig : fake.get());
 


### PR DESCRIPTION
OpenCV4 support : change old C definition to standard c++ one in use
the old definition still exist in imgproc.c_types.h

## Summary
OpenCV 4 made some changes regarding C definition in imgproc
I update them. It seems to work....

## Review
Should be compiled on Mac and Windows also.
I don't know if we need to check compatibility with OpenCV3


## Test coverage
- [ ] code already covered by the following tests:
- [ ] a new unit test is provided with this change set
- [ ] a new command line test is provided with this change set
- [ ] a new squish test is provided with this change set
- [ ] no test needed: ok but why?
