### PR TITLE
CUDA_LOCAL_ARCH_ONLY CMake fix

### DIFF
--- a/cmake/CUDAArch.cmake
+++ b/cmake/CUDAArch.cmake
@@ -21,9 +21,9 @@ if(CUDA_LOCAL_ARCH_ONLY)
                   OUTPUT_VARIABLE QUERY_CUDA_OUT
                   ERROR_VARIABLE QUERY_CUDA_ERR)
 
-  if((QUERY_CUDA_EXIT EQUAL 1) OR QUERY_CUDA_ERR)
+  if((QUERY_CUDA_EXIT EQUAL 1) OR ${QUERY_CUDA_ERR})
     message(FATAL_ERROR "Query for CUDA_LOCAL_ARCH_ONLY failed with message: ${QUERY_CUDA_OUT}\n${QUERY_CUDA_ERR}")
-  endif((QUERY_CUDA_EXIT EQUAL 1) OR QUERY_CUDA_ERR)
+  endif()
 
   # try out these settings with nvcc
   execute_process(COMMAND ${NVCC} --run cmake/configuration/helloWorld.cu ${CUDA_LOCAL_ARCH_FLAGS} --output-file ${CMAKE_CURRENT_BINARY_DIR}/testCUDACompilationFlags


### PR DESCRIPTION
Don't trigger FATAL_ERROR on CUDA_LOCAL_ARCH_ONLY on empty but existing QUERY_CUDA_ERR.

Don't know where this suddenly comes from (maybe CMake update?), but CMake configuration on Mac with CUDA_LOCAL_ARCH_ONLY suddenly failed although queryCUDAprops ran fine and QUERY_CUDA_ERR was empty 🤷‍♂️ 
