### PR TITLE
Disable NVENC output in Studio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+### Current master
+
+* disabled unsupported NVENC output options in VideoStitch Studio  (#88)
+
+### v2.4.0 (2020-05-03)
+
+* initial binary release

--- a/apps/src/videostitch-studio-gui/src/centralwidget/processtab/videoprocess.cpp
+++ b/apps/src/videostitch-studio-gui/src/centralwidget/processtab/videoprocess.cpp
@@ -108,6 +108,11 @@ void VideoProcess::updateSupportedCodecs() {
   ui->comboCodec->clear();
   QStringList codecs = currentFormat->getSupportedCodecs();
   codecs.removeOne(VideoStitch::VideoCodec::getStringFromEnum(VideoStitch::VideoCodec::VideoCodecEnum::MPEG4));
+
+  // TODO: not implemented in Studio (CodecFactory, formats/codecs)
+  codecs.removeOne(VideoStitch::VideoCodec::getStringFromEnum(VideoStitch::VideoCodec::VideoCodecEnum::NVENC_H264));
+  codecs.removeOne(VideoStitch::VideoCodec::getStringFromEnum(VideoStitch::VideoCodec::VideoCodecEnum::NVENC_HEVC));
+
   for (const QString& data : codecs) {
     const VideoStitch::VideoCodec::VideoCodecEnum codec = VideoStitch::VideoCodec::getEnumFromString(data);
     ui->comboCodec->addItem(VideoStitch::VideoCodec::getDisplayNameFromEnum(codec), data);


### PR DESCRIPTION
NVENC output feature was in development, not ready to be shipped. No UI currently for Studio, the codec factory doesn't deal with the NVENC variants, a nullptr is created, and Studio crashes.

We can have a look at finishing the feature at some point, but for now, remove the Studio crash from the unfinished code.

Closes #88.