### PR TITLE
Don't use const on image2d_t

### DIFF
--- a/lib/src/backend/common/coredepth/sphereSweep.gpu
+++ b/lib/src/backend/common/coredepth/sphereSweep.gpu
@@ -57,7 +57,7 @@ inline __device__ __host__ float clampf_vs(float v, float minVal, float maxVal) 
 // map scaled sphere to input
 // return color
 template <int PATCH_SIZE>
-__device__ void mapInput(float4* values, bool* written, const read_only image2d_t texture,
+__device__ void mapInput(float4* values, bool* written, read_only image2d_t texture,
                          struct InputParams inputParams, const float3* onRigSphere, const bool debug) {
   for (int k = 0; k < PATCH_SIZE; ++k) {
     *written = false;

--- a/lib/src/backend/common/image/downsampler.gpu
+++ b/lib/src/backend/common/image/downsampler.gpu
@@ -19,7 +19,7 @@ __global__ void downsampleMonoKernel(global_mem unsigned char* dst, const global
   }
 }
 
-__global__ void downsampleRGBASurfKernel(surface_t dst, const read_only image2d_t src, unsigned dstWidth,
+__global__ void downsampleRGBASurfKernel(surface_t dst, read_only image2d_t src, unsigned dstWidth,
                                          unsigned dstHeight) {
   const unsigned x = get_global_id_x();
   const unsigned y = get_global_id_y();


### PR DESCRIPTION
The type qualifiers const, restrict and volatile as defined by the C99 specification are supported. These qualifiers cannot be used with image2d_t or image3d_t type. Types other than pointer types shall not use the restrict qualifier.

Fixes #100 