### PR TITLE
First Batch of Presets (ZCam S1, GoPro Fusion, Yi360)

### DIFF
--- a/apps/src/videostitch-studio-gui/presets/rigs/GoPro Fusion.preset
+++ b/apps/src/videostitch-studio-gui/presets/rigs/GoPro Fusion.preset
@@ -1,0 +1,69 @@
+{
+  "rig" : {
+    "name" : "GoPro Fusion", 
+    "rigcameras" : [
+      {
+        "angle_unit" : "degrees", 
+        "yaw_mean" : 0, 
+        "pitch_mean" : 0, 
+        "roll_mean" : 0, 
+        "yaw_variance" : 0.5, 
+        "pitch_variance" : 0.5, 
+        "roll_variance" : 0.5, 
+        "camera" : "camera_0"
+      },
+      {
+        "angle_unit" : "degrees", 
+        "yaw_mean" : 168.23, 
+        "pitch_mean" : 6.21, 
+        "roll_mean" : 1.22, 
+        "yaw_variance" : 25, 
+        "pitch_variance" : 50, 
+        "roll_variance" : 7, 
+        "camera" : "camera_1"
+      }
+    ]
+  }, 
+  "cameras" : [
+    {
+      "name" : "camera_0", 
+      "format" : "circular_fisheye", 
+      "width" : 2704, 
+      "height" : 2624, 
+      "fu_mean" : 752.5, 
+      "fu_variance" : 150, 
+      "fv_mean" : 752.96, 
+      "fv_variance" : 200, 
+      "cu_mean" : 1413.93, 
+      "cu_variance" : 250, 
+      "cv_mean" : 1229.01, 
+      "cv_variance" : 250, 
+      "distorta_mean" : 0, 
+      "distorta_variance" : 0.05, 
+      "distortb_mean" : 0.03, 
+      "distortb_variance" : 0.15, 
+      "distortc_mean" : 0, 
+      "distortc_variance" : 0.05
+    },
+    {
+      "name" : "camera_1", 
+      "format" : "circular_fisheye", 
+      "width" : 2704, 
+      "height" : 2624, 
+      "fu_mean" : 752.5, 
+      "fu_variance" : 150, 
+      "fv_mean" : 752.96, 
+      "fv_variance" : 200, 
+      "cu_mean" : 1305.28, 
+      "cu_variance" : 250, 
+      "cv_mean" : 1214.13, 
+      "cv_variance" : 250, 
+      "distorta_mean" : 0, 
+      "distorta_variance" : 0.05, 
+      "distortb_mean" : 0.02, 
+      "distortb_variance" : 0.15, 
+      "distortc_mean" : 0, 
+      "distortc_variance" : 0.05
+    }
+  ]
+}

--- a/apps/src/videostitch-studio-gui/presets/rigs/YI360.preset
+++ b/apps/src/videostitch-studio-gui/presets/rigs/YI360.preset
@@ -1,0 +1,69 @@
+{
+  "rig" : {
+    "name" : "YI360", 
+    "rigcameras" : [
+      {
+        "angle_unit" : "degrees", 
+        "yaw_mean" : -0.324, 
+        "pitch_mean" : 0.546, 
+        "roll_mean" : -0.046, 
+        "yaw_variance" : 2, 
+        "pitch_variance" : 2, 
+        "roll_variance" : 1.5, 
+        "camera" : "camera_0"
+      },
+      {
+        "angle_unit" : "degrees", 
+        "yaw_mean" : 179.958, 
+        "pitch_mean" : 0.992, 
+        "roll_mean" : -0.1556, 
+        "yaw_variance" : 2, 
+        "pitch_variance" : 2, 
+        "roll_variance" : 1.5, 
+        "camera" : "camera_1"
+      }
+    ]
+  }, 
+  "cameras" : [
+    {
+      "name" : "camera_0", 
+      "format" : "circular_fisheye", 
+      "width" : 2880, 
+      "height" : 5760, 
+      "fu_mean" : 841.338, 
+      "fu_variance" : 100, 
+      "fv_mean" : 841.338, 
+      "fv_variance" : 100, 
+      "cu_mean" : 1440, 
+      "cu_variance" : 100, 
+      "cv_mean" : 1440, 
+      "cv_variance" : 100, 
+      "distorta_mean" : 0, 
+      "distorta_variance" : 0.05, 
+      "distortb_mean" : 0.0716241, 
+      "distortb_variance" : 0.000115425, 
+      "distortc_mean" : 0, 
+      "distortc_variance" : 0.05
+    },
+    {
+      "name" : "camera_1", 
+      "format" : "circular_fisheye", 
+      "width" : 2880, 
+      "height" : 5760, 
+      "fu_mean" : 841.338, 
+      "fu_variance" : 100, 
+      "fv_mean" : 841.338, 
+      "fv_variance" : 100, 
+      "cu_mean" : 1440, 
+      "cu_variance" : 100, 
+      "cv_mean" : 4320, 
+      "cv_variance" : 100, 
+      "distorta_mean" : 0, 
+      "distorta_variance" : 0.05, 
+      "distortb_mean" : 0.0716241, 
+      "distortb_variance" : 0.000115425, 
+      "distortc_mean" : 0, 
+      "distortc_variance" : 0.05
+    }
+  ]
+}

--- a/apps/src/videostitch-studio-gui/presets/rigs/ZCAM S1.preset
+++ b/apps/src/videostitch-studio-gui/presets/rigs/ZCAM S1.preset
@@ -1,0 +1,129 @@
+{
+  "rig" : {
+    "name" : "ZCAM S1", 
+    "rigcameras" : [
+      {
+        "angle_unit" : "degrees", 
+        "yaw_mean" : 0, 
+        "pitch_mean" : -0.28, 
+        "roll_mean" : -90.41, 
+        "yaw_variance" : 0.5, 
+        "pitch_variance" : 2.5, 
+        "roll_variance" : 2.5, 
+        "camera" : "camera_0"
+      },
+      {
+        "angle_unit" : "degrees", 
+        "yaw_mean" : -88.17, 
+        "pitch_mean" : 0.57, 
+        "roll_mean" : -89.8, 
+        "yaw_variance" : 2.5, 
+        "pitch_variance" : 2, 
+        "roll_variance" : 2, 
+        "camera" : "camera_1"
+      },
+      {
+        "angle_unit" : "degrees", 
+        "yaw_mean" : -178.99, 
+        "pitch_mean" : -0.17, 
+        "roll_mean" : -89.98, 
+        "yaw_variance" : 2, 
+        "pitch_variance" : 2, 
+        "roll_variance" : 1.5, 
+        "camera" : "camera_2"
+      },
+      {
+        "angle_unit" : "degrees", 
+        "yaw_mean" : 92.37, 
+        "pitch_mean" : 0.02, 
+        "roll_mean" : -89.53, 
+        "yaw_variance" : 3, 
+        "pitch_variance" : 2.2, 
+        "roll_variance" : 2, 
+        "camera" : "camera_3"
+      }
+    ]
+  }, 
+  "cameras" : [
+    {
+      "name" : "camera_0", 
+      "format" : "circular_fisheye", 
+      "width" : 3840, 
+      "height" : 2160, 
+      "fu_mean" : 911.11, 
+      "fu_variance" : 40, 
+      "fv_mean" : 911.11, 
+      "fv_variance" : 40, 
+      "cu_mean" : 1919.13, 
+      "cu_variance" : 30, 
+      "cv_mean" : 1079.89, 
+      "cv_variance" : 30, 
+      "distorta_mean" : -0.1, 
+      "distorta_variance" : 0.2, 
+      "distortb_mean" : 0.09, 
+      "distortb_variance" : 0.2, 
+      "distortc_mean" : -0.04, 
+      "distortc_variance" : 0.1
+    },
+    {
+      "name" : "camera_1", 
+      "format" : "circular_fisheye", 
+      "width" : 3840, 
+      "height" : 2160, 
+      "fu_mean" : 907.09, 
+      "fu_variance" : 40, 
+      "fv_mean" : 907.09, 
+      "fv_variance" : 40, 
+      "cu_mean" : 1919.13, 
+      "cu_variance" : 30, 
+      "cv_mean" : 1079.89, 
+      "cv_variance" : 30, 
+      "distorta_mean" : -0.1, 
+      "distorta_variance" : 0.2, 
+      "distortb_mean" : 0.09, 
+      "distortb_variance" : 0.2, 
+      "distortc_mean" : -0.04, 
+      "distortc_variance" : 0.1
+    },
+    {
+      "name" : "camera_2", 
+      "format" : "circular_fisheye", 
+      "width" : 3840, 
+      "height" : 2160, 
+      "fu_mean" : 907.21, 
+      "fu_variance" : 40, 
+      "fv_mean" : 907.21, 
+      "fv_variance" : 40, 
+      "cu_mean" : 1919.13, 
+      "cu_variance" : 30, 
+      "cv_mean" : 1079.89, 
+      "cv_variance" : 30, 
+      "distorta_mean" : -0.1, 
+      "distorta_variance" : 0.2, 
+      "distortb_mean" : 0.09, 
+      "distortb_variance" : 0.2, 
+      "distortc_mean" : -0.04, 
+      "distortc_variance" : 0.1
+    },
+    {
+      "name" : "camera_3", 
+      "format" : "circular_fisheye", 
+      "width" : 3840, 
+      "height" : 2160, 
+      "fu_mean" : 904.05, 
+      "fu_variance" : 40, 
+      "fv_mean" : 904.05, 
+      "fv_variance" : 40, 
+      "cu_mean" : 1919.13, 
+      "cu_variance" : 30, 
+      "cv_mean" : 1079.89, 
+      "cv_variance" : 30, 
+      "distorta_mean" : -0.1, 
+      "distorta_variance" : 0.2, 
+      "distortb_mean" : 0.09, 
+      "distortb_variance" : 0.2, 
+      "distortc_mean" : -0.04, 
+      "distortc_variance" : 0.1
+    }
+  ]
+}

--- a/apps/src/videostitch-studio-gui/videostitch-studio-gui.qrc
+++ b/apps/src/videostitch-studio-gui/videostitch-studio-gui.qrc
@@ -6,6 +6,9 @@
         <file>presets/rigs/360Heroes - H3PRO7 (1440p).preset</file>
         <file>presets/rigs/360Heroes - H3PRO10HD (2.7K).preset</file>
         <file>presets/rigs/360Heroes - H3PRO10HD (1080p).preset</file>
+        <file>presets/rigs/ZCAM S1.preset</file>
+        <file>presets/rigs/GoPro Fusion.preset</file>
+        <file>presets/rigs/YI360.preset.preset</file>
         <file>presets/calibration/default_studio.preset</file>
         <file>presets/mask/default_studio.preset</file>
         <file>presets/project/default_project.preset</file>


### PR DESCRIPTION
## Summary
Adding Presets for current 360° cameras to make VSS even easier to use.

## Review
See if the rigs show up in the Calibration window.
Check if the stitch works with the provided footage. (Check below)

## Test coverage
Tested with various footage - Sample footage here:
https://drive.google.com/drive/folders/1IAP9YMmXpzvCJ0e_qb4X3InD1qfZFZpX?usp=sharing
