### PR TITLE
macOS Big Sur support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
-### Current master
+### v2.4.1 (2021-03-03)
 
-* disabled unsupported NVENC output options in VideoStitch Studio  (#88)
+* disabled unsupported NVENC output options in VideoStitch Studio (#88)
+* fix Vahana VR close button (#97)
+* PTGui file parsing with float e+ notation (#98)
+* fix OpenCL compilation errors for some GPUs (e.g. R9 280x), don't use const on image2d_t (#115)
+* presets for ZCam S1, GoPro Fusion, Yi360
+* macOS Big Sur support, building with Qt 5.12.10
 
 ### v2.4.0 (2020-05-03)
 


### PR DESCRIPTION
Building on macOS Big Sur 11.2.2 with MacPorts and Qt 5.12.10, it doesn't appear to be hanging.

So it seems #134 can be fixed by updating Qt to 5.12.10? Other Qt projects had similar issues: https://bugreports.qt.io/browse/QTBUG-87014.

Updating the CHANGELOG with this PR, then I'll create a new binary for macOS from master.