### PR TITLE
Changing release link from releases/latest to releases/

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Technical issues can be directly reported on [GitHub](https://github.com/stitchE
 
 ## Download
 
-Builds of Vahana VR and VideoStitch Studio for Windows and macOS can be downloaded in the [release section](https://github.com/stitchEm/stitchEm/releases/latest).
+Builds of Vahana VR and VideoStitch Studio for Windows and macOS can be downloaded in the [release section](https://github.com/stitchEm/stitchEm/releases/).
 
 ## Build
 


### PR DESCRIPTION
The latest release only contains mac binaries. Instead point to the releases page, which makes it easier for Windows users to find the Studio/Vahana build for Windows.